### PR TITLE
!WARNING! --allow-unrelated-histories

### DIFF
--- a/.github/workflows/AutoMergeMaintoBranch1.yaml
+++ b/.github/workflows/AutoMergeMaintoBranch1.yaml
@@ -20,5 +20,5 @@ jobs:
           git config user.email 'Akiyasu.Sakagami@gmail.com'
           git fetch origin branch1
           git checkout branch1
-          git merge origin/main
+          git merge origin/main ‐-allow-unrelated-histories
           git push origin branch1


### PR DESCRIPTION
--allow-unrelated-histories オプションの使用: エラーメッセージに対処する最も直接的な方法は、--allow-unrelated-histories オプションを使用して、関連性のない履歴を持つブランチ間のマージを強制することです。このオプションは、履歴が異なるブランチ間でのマージを許可します。